### PR TITLE
给doScript 运行的脚本增加几个全局变量，file、cwd、refs_path

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -574,6 +574,9 @@
       var ctx, path, _ref, _ref1;
       ctx = context || {};
       ctx.path = utilpath;
+      ctx.file = utilfile;
+      ctx.cwd = this.baseUri;
+      ctx.refs_path = this.refs_path;
       ctx.io = {
         reader: new Reader(),
         writer: new Writer()

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -422,6 +422,9 @@ class FekitConfig
     doScript : ( type , context ) ->
         ctx = context || {}
         ctx.path = utilpath
+        ctx.file = utilfile
+        ctx.cwd = @baseUri
+        ctx.refs_path = @refs_path
         ctx.io =
             reader : new Reader()
             writer : new Writer()


### PR DESCRIPTION
  "refs": {
    "cp": [
      "ver",
      "src/html"
    ],
    "sh": "xxxx"
  },

使用这种配置时，vm和html里面的环境变量在拷贝到refs文件夹时会自动替换成真实的值，但是在“sh”属性指定的脚本执行时，refs里面的变量还没有被替换；

所以考虑在postmin对应的脚本上做；并给脚本增加全局属性，file,cwd,refs_path